### PR TITLE
Remove pinning of telegraf version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,7 @@ services:
     volumes:
       - marax-storage:/var/log/marax
   telegraf:
-    # Pin to 1.14 - tailing log file doesn't work on 1.15
-    image: telegraf:1.14
+    image: telegraf
     depends_on:
       - influxdb
       - marax-adapter


### PR DESCRIPTION
Originally saw on `1.15.x` log tailing wouldn't detect changes and nothing would get shovelled into influxdb.

Telegraf is now at `1.16.3` and log tailing looks to be working fine. 