### PR TITLE
Added types to the csv columns to attempt to avoid conflict

### DIFF
--- a/config/telegraf.conf
+++ b/config/telegraf.conf
@@ -82,6 +82,15 @@
     "fastHeating",
     "heatOn"
   ]
+  csv_column_types = [
+    "int",      # time
+    "string",   # mode-version
+    "int",      # steamTempActual
+    "int",      # steamTempTarget
+    "int",      # exchangerTempActual
+    "int",      # fastHeating
+    "int"       # heatOn
+  ]
   csv_timestamp_column = "time"
   csv_timestamp_format = "unix"
   pipe = true


### PR DESCRIPTION
Keep getting telegraf errors like this which stop the data pipeline working
```
telegraf_1       | 2021-04-24T18:11:23Z E! [outputs.influxdb] When writing to [http://influxdb:8086]: received error partial write: field type conflict: input field "mode-version" on measurement "tail" is type string, already exists as type float dropped=8; discarding points
```

`mode-version` should really be a string considering it looks like `C1.19` in the marax output
```
1619291335,C1.19,116,116,094,0000,0
```